### PR TITLE
feat: add wait for interaction functionality

### DIFF
--- a/components/SceneDisplay.tsx
+++ b/components/SceneDisplay.tsx
@@ -52,13 +52,27 @@ const SceneDisplay: React.FC<SceneProps> = ({ scene }) => {
 
 export default SceneDisplay
 
-const TempNarration: React.FC<Narration> = ({ shown, text, position }) => {
+const TempNarration: React.FC<Narration> = ({
+  shown,
+  text,
+  position,
+  afterInteractionCallback,
+}) => {
+  const handleInteraction = useCallback(() => {
+    if (afterInteractionCallback) {
+      afterInteractionCallback()
+    }
+  }, [afterInteractionCallback])
+
   if (!shown) {
     return null
   }
 
   return (
-    <div className="absolute px-4 py-3 m-auto bg-gray-100 border border-gray-700 rounded positioned h-max w-max">
+    <div
+      className="absolute px-4 py-3 m-auto bg-gray-100 border border-gray-700 rounded positioned h-max w-max"
+      onClick={handleInteraction}
+    >
       <span className="font-semibold text-gray-900 text-md">{text}</span>
       <style jsx>{`
         .positioned {
@@ -77,13 +91,23 @@ const TempDialogue: React.FC<Dialogue> = ({
   text,
   character,
   position,
+  afterInteractionCallback,
 }) => {
+  const handleInteraction = useCallback(() => {
+    if (afterInteractionCallback) {
+      afterInteractionCallback()
+    }
+  }, [afterInteractionCallback])
+
   if (!shown) {
     return null
   }
 
   return (
-    <div className="absolute px-4 py-3 m-auto bg-gray-100 border border-gray-700 rounded positioned h-max w-max">
+    <div
+      className="absolute px-4 py-3 m-auto bg-gray-100 border border-gray-700 rounded positioned h-max w-max"
+      onClick={handleInteraction}
+    >
       <div className="-mt-1">
         <span className="text-sm font-bold text-gray-500 leading-wide">
           {character}
@@ -104,13 +128,25 @@ const TempDialogue: React.FC<Dialogue> = ({
   )
 }
 
-const TempImage: React.FC<Image> = ({ shown, src, altText, position }) => {
+const TempImage: React.FC<Image> = ({
+  shown,
+  src,
+  altText,
+  position,
+  afterInteractionCallback,
+}) => {
+  const handleInteraction = useCallback(() => {
+    if (afterInteractionCallback) {
+      afterInteractionCallback()
+    }
+  }, [afterInteractionCallback])
+
   if (!shown) {
     return null
   }
 
   return (
-    <div className="absolute w-1/5 positioned">
+    <div className="absolute w-1/5 positioned" onClick={handleInteraction}>
       <img
         src={src}
         alt={altText || ''}
@@ -138,6 +174,7 @@ const TempClickable: React.FC<TempClickableProps> = ({
   options,
   position,
   sceneId,
+  afterInteractionCallback,
 }) => {
   const executeActions = useStore((state) => state.executeActions)
   const hideClickable = useStore((state) => state.hideClickable)
@@ -147,10 +184,21 @@ const TempClickable: React.FC<TempClickableProps> = ({
       const actions =
         options.find((option) => option.name === optionName)?.onClickActions ??
         ([] as Action[])
+
       hideClickable(sceneId, name)
       executeActions(...actions)
+      if (afterInteractionCallback) {
+        afterInteractionCallback()
+      }
     },
-    [executeActions, hideClickable, options, name, sceneId]
+    [
+      executeActions,
+      hideClickable,
+      options,
+      name,
+      sceneId,
+      afterInteractionCallback,
+    ]
   )
 
   if (!shown) {

--- a/components/SceneDisplay.tsx
+++ b/components/SceneDisplay.tsx
@@ -1,4 +1,6 @@
 import { useCallback, useEffect } from 'react'
+import { useAfterInteractionCallback } from '../hooks/useAfterInteractionCallback'
+import { useRunCleanupFnsOnUnmount } from '../hooks/useRunCleanupFnsOnUnmount'
 import { Action } from '../lib/actions'
 import {
   Clickable,
@@ -58,11 +60,9 @@ const TempNarration: React.FC<Narration> = ({
   position,
   afterInteractionCallback,
 }) => {
-  const handleInteraction = useCallback(() => {
-    if (afterInteractionCallback) {
-      afterInteractionCallback()
-    }
-  }, [afterInteractionCallback])
+  const handleInteraction = useAfterInteractionCallback(
+    afterInteractionCallback
+  )
 
   if (!shown) {
     return null
@@ -93,11 +93,9 @@ const TempDialogue: React.FC<Dialogue> = ({
   position,
   afterInteractionCallback,
 }) => {
-  const handleInteraction = useCallback(() => {
-    if (afterInteractionCallback) {
-      afterInteractionCallback()
-    }
-  }, [afterInteractionCallback])
+  const handleInteraction = useAfterInteractionCallback(
+    afterInteractionCallback
+  )
 
   if (!shown) {
     return null
@@ -135,11 +133,9 @@ const TempImage: React.FC<Image> = ({
   position,
   afterInteractionCallback,
 }) => {
-  const handleInteraction = useCallback(() => {
-    if (afterInteractionCallback) {
-      afterInteractionCallback()
-    }
-  }, [afterInteractionCallback])
+  const handleInteraction = useAfterInteractionCallback(
+    afterInteractionCallback
+  )
 
   if (!shown) {
     return null
@@ -178,6 +174,7 @@ const TempClickable: React.FC<TempClickableProps> = ({
 }) => {
   const executeActions = useStore((state) => state.executeActions)
   const hideClickable = useStore((state) => state.hideClickable)
+  const { addCleanupFns } = useRunCleanupFnsOnUnmount()
 
   const onClick = useCallback(
     (optionName: string) => {
@@ -186,14 +183,18 @@ const TempClickable: React.FC<TempClickableProps> = ({
         ([] as Action[])
 
       hideClickable(sceneId, name)
-      executeActions(...actions)
+      let cleanupFn = executeActions(...actions)
+      addCleanupFns(cleanupFn)
+
       if (afterInteractionCallback) {
-        afterInteractionCallback()
+        cleanupFn = afterInteractionCallback()
+        addCleanupFns(cleanupFn)
       }
     },
     [
       executeActions,
       hideClickable,
+      addCleanupFns,
       options,
       name,
       sceneId,

--- a/hooks/useAfterInteractionCallback.ts
+++ b/hooks/useAfterInteractionCallback.ts
@@ -1,0 +1,15 @@
+import { useCallback } from 'react'
+import { useRunCleanupFnsOnUnmount } from './useRunCleanupFnsOnUnmount'
+
+export function useAfterInteractionCallback(
+  afterInteractionCallback?: () => () => void
+) {
+  const { addCleanupFns } = useRunCleanupFnsOnUnmount()
+
+  return useCallback(() => {
+    if (afterInteractionCallback) {
+      const cleanupFn = afterInteractionCallback()
+      addCleanupFns(cleanupFn)
+    }
+  }, [afterInteractionCallback, addCleanupFns])
+}

--- a/hooks/useRunCleanupFnsOnUnmount.ts
+++ b/hooks/useRunCleanupFnsOnUnmount.ts
@@ -1,0 +1,15 @@
+import { useEffect, useRef } from 'react'
+
+export function useRunCleanupFnsOnUnmount() {
+  const cleanupRef = useRef([] as (() => void)[])
+  useEffect(() => {
+    const cleanup = cleanupRef.current
+    return () => cleanup.forEach((fn) => fn())
+  }, [])
+
+  return {
+    addCleanupFns(...cleanupFns: (() => void)[]) {
+      cleanupRef.current.push(...cleanupFns)
+    },
+  }
+}

--- a/lib/elements.ts
+++ b/lib/elements.ts
@@ -7,6 +7,14 @@ import {
 import { Action, makeAction } from './actions'
 import { isDefined } from './utils'
 
+// Add a key here and keep the `AllElements` list below in-sync when adding new elements
+export const narrations = 'narrations'
+export const dialogues = 'dialogues'
+export const images = 'images'
+export const clickables = 'clickables'
+
+export const allElements = [narrations, dialogues, images, clickables] as const
+
 export type Position = {
   top?: string | undefined
   left?: string | undefined
@@ -20,6 +28,7 @@ export interface Element {
   shown: boolean
   name: string
   position: Position
+  afterInteractionCallback?: () => () => void
 }
 
 export interface Narration extends Element {

--- a/schema/example-schema.json
+++ b/schema/example-schema.json
@@ -92,9 +92,16 @@
                 },
                 {
                     "type": "showDialogue",
-                    "value": "clown bait",
-                    "duration": 2000,
-                    "hideAfterShow": true
+                    "value": "clown bait"
+                },
+                {
+                    "type": "waitForInteraction",
+                    "elementType": "dialogues",
+                    "value": "clown bait"
+                },
+                {
+                    "type": "hideDialogue",
+                    "value": "clown bait"
                 },
                 {
                     "type": "showImage",


### PR DESCRIPTION
- New wait for interaction functionality, done using a `waitForInteraction` action

Example usage

![image](https://user-images.githubusercontent.com/43085321/135724658-e035f9c8-7fc2-4feb-b1e3-464cef3070ac.png)


When used, it will expose an `afterInteractionCallback` on the targeted element. That element should call the callback whenever "interaction" is considered to be over. For different elements this could be different things. For example, a dialogue might consider interaction over when all the lines of dialogue have been presented.