### PR TITLE
Fix game state when story is restarted

### DIFF
--- a/lib/actions.ts
+++ b/lib/actions.ts
@@ -101,6 +101,10 @@ export const DefinedActions: Partial<
     game.globalState.update(newState)
   },
 
+  resetGlobalState: ({ game }) => {
+    game.globalState.reset()
+  },
+
   ...ShowActions,
   ...HideActions,
 }

--- a/lib/state.ts
+++ b/lib/state.ts
@@ -7,27 +7,35 @@ type StateMap = Record<string, StateObj>
 
 export interface State {
   innerState: StateMap
+  reset(): void
   hasKey(key: string): boolean
   get(key: string): string | number | boolean | undefined
   update(newState: any): void
 }
 
 export function makeState(state: any): State {
-  let stateMap: StateMap = {}
-  for (const [key, val] of Object.entries(state)) {
-    switch (typeof val) {
-      case 'string':
-      case 'number':
-      case 'boolean':
-        stateMap[key] = { value: val } as StateObj
-        continue
-      default:
-        stateMap[key] = val as StateObj
+  function createStateMap(): StateMap {
+    let stateMap: StateMap = {}
+    for (const [key, val] of Object.entries(state)) {
+      switch (typeof val) {
+        case 'string':
+        case 'number':
+        case 'boolean':
+          stateMap[key] = { value: val } as StateObj
+          continue
+        default:
+          stateMap[key] = val as StateObj
+      }
     }
+    return stateMap
   }
 
   return {
-    innerState: stateMap,
+    innerState: createStateMap(),
+
+    reset(): void {
+      this.innerState = createStateMap()
+    },
 
     hasKey(key: string): boolean {
       return key in this.innerState

--- a/schema/mvp.json
+++ b/schema/mvp.json
@@ -77,15 +77,6 @@
                   "text": "Go",
                   "onClick": [
                     {
-                      "type": "updateGlobalState",
-                      "newState": {
-                        "date": "Monday",
-                        "wealth": 5,
-                        "health": 10,
-                        "social": 10
-                      }
-                    },
-                    {
                       "type": "gotoScene",
                       "sceneId": 1
                     }
@@ -213,9 +204,15 @@
           ],
           "intro": [
             {
+              "type": "resetGlobalState"
+            },
+            {
               "type": "updateGlobalState",
               "newState": {
-                "date": "Monday"
+                "date": "Monday",
+                "wealth": 5,
+                "health": 10,
+                "social": 10
               }
             },
             {


### PR DESCRIPTION
Previously, when a player finishes the story and clicks 'restart' the game data (wealth/health/social) is not reset, continuing into the next playthrough. 

This is fixed with the addition of a new action, `resetGlobalState`. It allows any `State` to reset to the original parameters given during creation.
- However, the initial value of each point system is 0 since the character is not determined yet. Hence we still need an `updateGlobalState` from one of the first few scenes to then properly set each value.
- As a result, note that since the restart button at the end of scene 14 points to scene 1 and not scene 0, the initialization must be moved from the end of scene 0 to the start of scene 1.

A downside of this approach is that the actions are now a bit clunkier, since reset and reinitialization are two distinct actions. Maybe it can be refined further.