### PR TITLE
minor: Remove usage of duration in show action

### DIFF
--- a/schema/mvp.json
+++ b/schema/mvp.json
@@ -226,7 +226,7 @@
               "type": "showImage",
               "value": "family",
               "autoHide": false,
-              "duration": 1
+              "waitForInteraction": false
             },
             {
               "type": "showNarration",
@@ -236,7 +236,7 @@
               "type": "showImage",
               "value": "work",
               "autoHide": false,
-              "duration": 1
+              "waitForInteraction": false
             },
             {
               "type": "showNarration",


### PR DESCRIPTION
These are the only remaining instances where `duration` is used in a `show_____` action.

Instead of setting a duration to 1 millisecond, the more appropriate solution is to use `"waitForInteraction": false` in order to immediately advance to the next action.