### PR TITLE
Fix state checks when boundaries are 0

### DIFF
--- a/lib/state.ts
+++ b/lib/state.ts
@@ -58,9 +58,9 @@ export function makeState(state: any): State {
             let newValue = (this.innerState[key].value as number) + val
             let min = this.innerState[key].min
             let max = this.innerState[key].max
-            if (min && newValue < min) {
+            if (min !== undefined && newValue < min) {
               newValue = min
-            } else if (max && newValue > max) {
+            } else if (max !== undefined && newValue > max) {
               newValue = max
             }
             ;(this.innerState[key].value as number) = newValue


### PR DESCRIPTION
If `min` or `max` is explicitly set to 0, since `0` is a falsy value the constraint will not be checked at all. This is fixed by directly checking whether the boundary itself is `!== undefined`.